### PR TITLE
Run as a non-root user account and use tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM python:3.10-slim-buster
 
-COPY app.py .
+# Install tini and create an unprivileged user
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /sbin/tini
+RUN addgroup --gid 1002 "gate" && \
+      adduser --disabled-password --gecos "GATE User,,," \
+      --home /gate --ingroup gate --uid 1002 gate && \
+      chmod +x /sbin/tini
+
 RUN pip install Flask Flask-API gunicorn
-CMD ["gunicorn"  , "--bind", "0.0.0.0:8000", "app:app"]
+
+COPY --chown=gate:gate app.py /gate/
+USER gate:gate
+WORKDIR /gate
+CMD ["/sbin/tini", "--", "gunicorn"  , "--bind", "0.0.0.0:8000", "app:app"]


### PR DESCRIPTION
Make the image run as a non-root user, and use `tini` as PID 1 instead of `python`.

Closes #1