### PR TITLE
relax checking on data type to allow MultiDict

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,8 +41,8 @@ def successful_call(payload: dict):
           product: payload,
     }))
 
-def valid_payload(payload: dict) -> bool:
-    if type(payload) == dict:
+def valid_payload(payload) -> bool:
+    try:
         return payload.get('product') in VALID_PRODUCT_NAMES
-    else:
+    except:
         return False


### PR DESCRIPTION
~Strict checking that `type(data) == dict` was failing the check on data which was a werkzeug `MultiDict`.~

Setting the content-type [on the sending end](https://github.com/GateNLP/gate-teamware/pull/333) correctly as `application/json` is a neater way of doing this, closing this PR.